### PR TITLE
Update InventoryCollector-Role.yml

### DIFF
--- a/templates/InventoryCollector-Role.yml
+++ b/templates/InventoryCollector-Role.yml
@@ -25,7 +25,7 @@ Resources:
             Action: "sts:AssumeRole"
       Path: "/"
       ManagedPolicyArns: 
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSConfigRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWS_ConfigRole
 
 Outputs: 
   InventoryCollectorLambdaExecuteRoleArn: 


### PR DESCRIPTION
*Issue #, if available:* `n/a`

*Description of changes: `To fix CF creation error`


The IAM Policy [`service-role/AWSConfigRole`](https://github.com/aws-samples/fedramp-integrated-inventory-workbook/blob/16a0d611dae47399cc31e09c4a2af2ff81e66ed7/templates/InventoryCollector-Role.yml#L28) that this CloudFormation was configured to use  was deprecated in July 2022. 

Currently as of June 2023, an error is observed when deploying this CloudFormation stack:

![image](https://github.com/aws-samples/fedramp-integrated-inventory-workbook/assets/37211844/6467d446-c4b6-409d-9816-abc83ee17f05)

```text
Policy arn:aws:iam::aws:policy/service-role/AWSConfigRole does not exist or is not attachable. 
(
   Service: AmazonIdentityManagement; 
   Status Code: 404; 
   Error Code: NoSuchEntity; 
   Request ID: 8a00c27e-b8d5-4e67-b7ce-57a295cd89fb; Proxy: null
)
```

According to the following [AWS blog post](https://aws.amazon.com/blogs/mt/service-notice-upcoming-changes-required-for-aws-config/), this role should be updated to reference `service-role/AWS_ConfigRole`





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
