### PR TITLE
Bugfix: Add support for ELBv2 Gateway Load Balancers

### DIFF
--- a/src/inventory/mappers.py
+++ b/src/inventory/mappers.py
@@ -124,7 +124,7 @@ class ElbDataMapper(DataMapper):
                  "unique_id": config_resource["arn"],
                  "is_virtual": "Yes",
                  "authenticated_scan_planned": "Yes",
-                 "is_public": "Yes" if config_resource["configuration"]["scheme"] == "internet-facing" else "No",
+                 "is_public": "Yes" if config_resource.get("configuration").get("scheme", "unknown") == "internet-facing" else "No",
                  # Classic ELBs have key of "vpcid" while V2 ELBs have key of "vpcId"
                  "network_id": config_resource["configuration"]["vpcId"] if "vpcId" in config_resource["configuration"] else config_resource["configuration"]["vpcid"],
                  "owner": _get_tag_value(config_resource["tags"], "owner") }


### PR DESCRIPTION
GLBs do not contain scheme in configuration returned through AWS Config. 

Use dict.get() method to try and get scheme to avoid KeyError with Gateway Load Balancers. 

---

This PR fixes the following error:

```text
[ERROR] KeyError: 'scheme'
Traceback (most recent call last):
  File "/var/task/inventory/handler.py", line 8, in lambda_handler
    inventory = AwsConfigInventoryReader(lambda_context=context).get_resources_from_all_accounts()
  File "/var/task/inventory/readers.py", line 88, in get_resources_from_all_accounts
    if len(inventory_items := mapper.map(resource)) > 0:
  File "/var/task/inventory/mappers.py", line 65, in map
    mapped_data.extend(self._do_mapping(config_resource))
  File "/var/task/inventory/mappers.py", line 147, in _do_mapping
    "is_public": "Yes" if config_resource["configuration"]["scheme"] == "internet-facing" else "No"
```


